### PR TITLE
Fixing bug at pin variable

### DIFF
--- a/concretesensor/pir.py
+++ b/concretesensor/pir.py
@@ -44,6 +44,6 @@ class PIR(MotionSensor):
         @rtype: Boolean
         """
         
-        return (GPIO.input(self.pin) == 1)
+        return (GPIO.input(self.__pin) == 1)
 
 


### PR DESCRIPTION
Because of the error running the example

python pirExample.py

Traceback (most recent call last):
  File "pirExample.py", line 14, in <module>
    print(sensor.isMotionDetected())
  File "/tmp/raspboardpy/dashboard/env/local/lib/python2.7/site-packages/concretesensor/pir.py", line 47, in isMotionDetected
    return (GPIO.input(self.pin) == 1)
AttributeError: 'PIR' object has no attribute 'pin'
